### PR TITLE
Set required property title

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -477,11 +477,15 @@ export class Validator {
             if (editor && editor.dependenciesFulfilled === false) return
             /* Ignore required error if editor is of type "button" or "info" */
             if (editor && ['button', 'info'].includes(editor.schema.format || editor.schema.type)) return
+            let title = schema && schema.properties && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : null
+            if (title === null) {
+              title = editor && editor.schema && editor.schema.title ? editor.schema.title : e
+            }
             errors.push({
               path,
               property: 'required',
-              message: this.translate('error_required', [schema && schema.properties && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : e], schema),
-              required_property: schema && schema.properties && schema.properties[e] && schema.properties[e].title ? schema.properties[e].title : e
+              message: this.translate('error_required', [title], schema),
+              required_property: e
             })
           })
         }


### PR DESCRIPTION
If the standard way of getting the property does not work, in the case when the validation error is from the anyOf schema, get the title from the editor schema instead.

If that does not exist continue to fallback to the key name

[
<img width="668" alt="Screenshot 2025-06-24 at 15 21 57" src="https://github.com/user-attachments/assets/adad5c71-4075-4680-be72-208c4a29d00f" />
](url)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️❌
| New feature?  | ✔️❌
| Is backward-compatible?    | ✔️❌
| Tests pass?   | ✔️❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ✔️❌
| Added CHANGELOG entry?   | ✔️❌
